### PR TITLE
MS_US2_T4 

### DIFF
--- a/PodConnect/Screens/MapView.swift
+++ b/PodConnect/Screens/MapView.swift
@@ -167,10 +167,12 @@ struct sBar: View {
     @Binding var activeCategories: Set<String>
     @Binding var selectedLocation: MapLocation?
 
+    // Unique category names for filter chips
     private var availableCategories: [String] {
         Array(Set(categories.values)).filter { $0 != "Classrooms" }.sorted()
     }
 
+    // Locations filtered by search text
     private var searchResults: [MapLocation] {
         guard !sText.isEmpty else { return [] }
         return locations.filter { $0.name.localizedCaseInsensitiveContains(sText) }
@@ -207,6 +209,7 @@ struct sBar: View {
 
                 Divider()
 
+                // Search results
                 if sText.isEmpty {
                     Spacer()
                     Text("Search for a campus location")


### PR DESCRIPTION
 Connects the search bar (KC_US2_T2) and campus location data to create a fully interactive search and
 filter on the map. Category filter chips in the search sheet toggle marker visibility on the map in real time. Search filters campus locations by name, tapping a result closes the sheet and flies the map to that location.