### PR TITLE
MS US2 T4 T5

### DIFF
--- a/PodConnect/Screens/MapView.swift
+++ b/PodConnect/Screens/MapView.swift
@@ -184,6 +184,19 @@ struct sBar: View {
                 // Filter chips
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack {
+                        // Clear button — only shows when filters are active
+                        if !activeCategories.isEmpty {
+                            Button(action: { activeCategories.removeAll() }) {
+                                Text("Clear")
+                                    .font(.caption)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .background(Color.red.opacity(0.15))
+                                    .foregroundColor(.red)
+                                    .clipShape(Capsule())
+                            }
+                        }
+
                         ForEach(availableCategories, id: \.self) { category in
                             let isActive = activeCategories.contains(category)
                             Button(action: {


### PR DESCRIPTION
(T4) Connects the search bar (KC_US2_T2) and campus location data to create a fully interactive search and
filter on the map. Category filter chips in the search sheet toggle marker visibility on the map in real time. Search filters campus locations by name, tapping a result closes the sheet and flies the map to that location.

(T5) Clear button appears when filters are active, resets all filters and restores all markers in one tap.