### PR TITLE
show dates on assignments popup from homescreen

### DIFF
--- a/PodConnect.xcodeproj/project.pbxproj
+++ b/PodConnect.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 				CODE_SIGN_ENTITLEMENTS = PodConnect/PodConnect.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = LGB3JDUUK3;
+				DEVELOPMENT_TEAM = NLM232548H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PodConnect/Info.plist;
@@ -309,7 +309,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.noah.PodConnect;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kassidysaffa.PodConnect;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -329,7 +329,7 @@
 				CODE_SIGN_ENTITLEMENTS = PodConnect/PodConnect.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = LGB3JDUUK3;
+				DEVELOPMENT_TEAM = NLM232548H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PodConnect/Info.plist;
@@ -345,7 +345,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.noah.PodConnect;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kassidysaffa.PodConnect;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;

--- a/PodConnect/Componets/ClassesCardView.swift
+++ b/PodConnect/Componets/ClassesCardView.swift
@@ -23,6 +23,7 @@ struct ClassesCardView: View {
         return userEvents
             .filter { event in
                 event.category == .academic &&
+                event.endDate >= Date() &&
                 event.startDate >= today &&
                 event.startDate < tomorrow
             }

--- a/PodConnect/Componets/ClassesCardView.swift
+++ b/PodConnect/Componets/ClassesCardView.swift
@@ -23,7 +23,6 @@ struct ClassesCardView: View {
         return userEvents
             .filter { event in
                 event.category == .academic &&
-                event.endDate >= Date() && //can remove event.endDate >= Date() form conditional if want home to show classes that already passed today
                 event.startDate >= today &&
                 event.startDate < tomorrow
             }

--- a/PodConnect/Componets/ClassesCardView.swift
+++ b/PodConnect/Componets/ClassesCardView.swift
@@ -27,7 +27,12 @@ struct ClassesCardView: View {
                 event.startDate >= today &&
                 event.startDate < tomorrow
             }
-            .sorted { $0.startDate < $1.startDate }
+            .sorted {
+                if $0.startDate == $1.startDate {
+                    return $0.endDate < $1.endDate
+                }
+                return $0.startDate < $1.startDate
+            }
     }
 
     var body: some View {

--- a/PodConnect/Componets/EventsCardView.swift
+++ b/PodConnect/Componets/EventsCardView.swift
@@ -54,7 +54,15 @@ struct EventsCardView: View {
                 )
             }
 
-        return Array((personal + school).sorted { $0.startTime < $1.startTime }.prefix(3))
+        return Array(
+            (personal + school).sorted {
+                if $0.startTime == $1.startTime {
+                    return ($0.endTime ?? $0.startTime) < ($1.endTime ?? $1.startTime)
+                }
+                return $0.startTime < $1.startTime
+            }
+            .prefix(3)
+        )
     }
 
     private func schoolIcon(for category: String) -> String {

--- a/PodConnect/Screens/AddClassView.swift
+++ b/PodConnect/Screens/AddClassView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 struct AddClassView: View {
     @Environment(\.dismiss) private var dismiss
-    let onSave: ([UserEvent]) -> Void
+    let onSave: ([UserEvent], String) -> Void
 
     @State private var className = ""
     @State private var room = ""
@@ -74,7 +74,16 @@ struct AddClassView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
-                        onSave(buildEvents())
+                        let events = buildEvents()
+
+                        guard !events.isEmpty else {
+                            return
+                        }
+
+                        onSave(
+                            events,
+                            className.trimmingCharacters(in: .whitespacesAndNewlines)
+                        )
                         dismiss()
                     }
                     .fontWeight(.semibold)
@@ -94,7 +103,7 @@ struct AddClassView: View {
         let endComponents = cal.dateComponents([.hour, .minute], from: endTime)
 
         var events: [UserEvent] = []
-        var cursor = Date()
+        var cursor = cal.startOfDay(for: Date())
 
         while cursor <= semesterEnd {
             let weekday = cal.component(.weekday, from: cursor)

--- a/PodConnect/Screens/AssignmentsListView.swift
+++ b/PodConnect/Screens/AssignmentsListView.swift
@@ -22,6 +22,14 @@ struct AssignmentsListView: View {
         case .thirtyDays: return viewModel.next30DaysAssignments
         }
     }
+    
+    private func dueDateText(for assignment: CanvasAssignment) -> String {
+        if selectedRange == .today {
+            return assignment.dueDate.formatted(.dateTime.hour().minute())
+        } else {
+            return assignment.dueDate.formatted(.dateTime.month(.abbreviated).day().hour().minute())
+        }
+    }
 
     var body: some View {
         ZStack {
@@ -58,7 +66,7 @@ struct AssignmentsListView: View {
                                         .strikethrough(assignment.isCompleted)
                                         .foregroundColor(assignment.isCompleted ? .secondary : .primary)
 
-                                    Text(assignment.dueDate, style: .time)
+                                    Text(dueDateText(for: assignment))
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }

--- a/PodConnect/Screens/AssignmentsListView.swift
+++ b/PodConnect/Screens/AssignmentsListView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct AssignmentsListView: View {
     @EnvironmentObject var viewModel: AssignmentsViewModel
     @State private var selectedRange: AssignmentRange = .today
+    @State private var showCanvasHelp = false
 
     
     
@@ -86,6 +87,50 @@ struct AssignmentsListView: View {
         }
         .navigationTitle("Assignments")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showCanvasHelp = true
+                } label: {
+                    Image(systemName: "questionmark.circle")
+                }
+            }
+        }
+        
+        .sheet(isPresented: $showCanvasHelp) {
+            NavigationStack {
+                VStack(spacing: 16) {
+                    Image(systemName: "questionmark.circle.fill")
+                        .font(.system(size: 42))
+                        .foregroundColor(Color.islandsBlue)
+
+                    Text("How to import Canvas assignments")
+                        .font(.headline)
+
+                    Text("Paste your Canvas calendar link in Profile → Account Settings → Connect Canvas. Once connected, your Canvas assignments will appear here, on Home, and in Calendar.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+
+                    NavigationLink {
+                        AccountSettingsView()
+                    } label: {
+                        Text("Open Account Settings")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.islandsBlue)
+                            .foregroundColor(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                    }
+
+                    Spacer()
+                }
+                .padding()
+                .navigationTitle("Canvas Help")
+                .navigationBarTitleDisplayMode(.inline)
+            }
+        }
     }
 
     private var emptyState: some View {

--- a/PodConnect/Screens/CalendarView.swift
+++ b/PodConnect/Screens/CalendarView.swift
@@ -533,6 +533,14 @@ struct EventsTabView: View {
 
         return searchFiltered.sorted { $0.startDate < $1.startDate }
     }
+    
+    private var filteredClassEvents: [UserEvent] {
+        filteredUserEvents.filter { $0.category == .academic }
+    }
+
+    private var filteredPersonalEvents: [UserEvent] {
+        filteredUserEvents.filter { $0.category != .academic }
+    }
 
     private var groupedSchoolEvents: [(String, [SchoolEvent])] {
         let formatter = DateFormatter()
@@ -606,9 +614,9 @@ struct EventsTabView: View {
                     }
                 }
                 
-                if !filteredUserEvents.isEmpty {
-                    Section("My Events") {
-                        ForEach(filteredUserEvents) { event in
+                if !filteredClassEvents.isEmpty {
+                    Section("Classes") {
+                        ForEach(filteredClassEvents) { event in
                             Button {
                                 selectedDate = event.startDate
                                 selectedTab = 0
@@ -643,7 +651,45 @@ struct EventsTabView: View {
                             }
                         }
                     }
-                
+                }
+
+                if !filteredPersonalEvents.isEmpty {
+                    Section("My Events") {
+                        ForEach(filteredPersonalEvents) { event in
+                            Button {
+                                selectedDate = event.startDate
+                                selectedTab = 0
+                            } label: {
+                                UserEventRow(event: event)
+                            }
+                            .buttonStyle(.plain)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    if event.recurrenceGroupId != nil {
+                                        eventPendingDelete = event
+                                    } else {
+                                        onDeleteEvent(event)
+                                    }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                Button {
+                                    eventToEdit = event
+                                    if event.recurrenceGroupId != nil {
+                                        showEditConfirmation = true
+                                    } else {
+                                        editScope = .single
+                                        showEditSheet = true
+                                    }
+                                } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                .tint(Color.islandsBlue)
+                            }
+                        }
+                    }
                 }
                 
             

--- a/PodConnect/Screens/CalendarView.swift
+++ b/PodConnect/Screens/CalendarView.swift
@@ -265,7 +265,12 @@ struct CalendarTabView: View {
     private var userEventsOnDate: [UserEvent] {
         return userEvents
             .filter { Calendar.current.isDate($0.startDate, inSameDayAs: selectedDate) }
-            .sorted { $0.startDate < $1.startDate }
+            .sorted {
+                if $0.startDate == $1.startDate {
+                    return $0.endDate < $1.endDate
+                }
+                return $0.startDate < $1.startDate
+            }
     }
 
     private var classEventsOnDate: [UserEvent] {
@@ -456,6 +461,7 @@ struct EventsTabView: View {
     var onDeleteSeries: (String) -> Void
     var onEditEvent: (UserEvent) -> Void
     var onEditSeries: (UserEvent) -> Void
+    @EnvironmentObject var assignmentsViewModel: AssignmentsViewModel
     @State private var eventPendingDelete: UserEvent?
     @State private var eventToEdit: UserEvent?
     @State private var editScope: EditScope = .single
@@ -531,7 +537,12 @@ struct EventsTabView: View {
             }
         }
 
-        return searchFiltered.sorted { $0.startDate < $1.startDate }
+        return searchFiltered.sorted {
+            if $0.startDate == $1.startDate {
+                return $0.endDate < $1.endDate
+            }
+            return $0.startDate < $1.startDate
+        }
     }
     
     private var filteredClassEvents: [UserEvent] {
@@ -610,6 +621,28 @@ struct EventsTabView: View {
                                 CanvasAssignmentRow(assignment: assignment)
                             }
                             .buttonStyle(.plain)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    Task {
+                                        await assignmentsViewModel.deleteAssignment(assignment)
+                                    }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                Button {
+                                    Task {
+                                        await assignmentsViewModel.toggleCompleted(assignment)
+                                    }
+                                } label: {
+                                    Label(
+                                        assignment.isCompleted ? "Undo" : "Complete",
+                                        systemImage: assignment.isCompleted ? "arrow.uturn.backward" : "checkmark"
+                                    )
+                                }
+                                .tint(Color.islandsBlue)
+                            }
                         }
                     }
                 }
@@ -812,55 +845,107 @@ struct SchoolEventRow: View {
 struct UserEventRow: View {
     let event: UserEvent
 
+    private var classLocation: String? {
+        let parts = event.title.components(separatedBy: "—")
+
+        if parts.count > 1 {
+            return parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return nil
+    }
+
+    private var cleanTitle: String {
+        event.title.components(separatedBy: "—").first?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? event.title
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
+
             HStack(spacing: 6) {
-                Text(event.title)
+                Text(cleanTitle)
                     .font(.body)
+
                 if event.recurrenceGroupId != nil {
                     Image(systemName: "repeat")
                         .font(.caption)
                         .foregroundColor(Color.islandsBlue)
                 }
             }
+
             HStack {
-                Text(event.startDate, style: .date)
+                Text(event.startDate, style: .time)
+                    .font(.caption)
+                    .foregroundColor(Color.islandsBlue)
+
+                Text("·")
+                    .foregroundColor(.secondary)
+
+                Text(event.category.rawValue)
+                    .font(.caption)
+                    .foregroundColor(categoryColor(event.category.rawValue))
+            }
+
+            Text(
+                "\(event.startDate.formatted(.dateTime.month().day().year()))  \(event.startDate.formatted(.dateTime.hour().minute())) – \(event.endDate.formatted(.dateTime.hour().minute()))"
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+
+            if event.category == .academic, let location = classLocation {
+                Label(location, systemImage: "mappin")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                Text(event.startDate, style: .time)
-                Text("–")
-                Text(event.endDate, style: .time)
-            }
-            .font(.caption)
-            .foregroundColor(.gray)
 
-            Text(event.category.rawValue)
-                .font(.caption)
-                .foregroundColor(Color.channelClay)
-
-            if !event.notes.isEmpty {
-                Text(event.notes)
+            } else if !event.notes.isEmpty {
+                Label(event.notes, systemImage: "note.text")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
         }
         .padding(.vertical, 4)
     }
+
+    func categoryColor(_ category: String) -> Color {
+        switch category {
+        case "Academic": return Color.islandsBlue
+        case "Arts": return Color.channelClay
+        case "Campus Life": return Color.islandsBlue
+        case "Wellness": return Color.channelClay
+        case "Personal": return Color.channelClay
+        default: return .gray
+        }
+    }
 }
+
 
 struct CanvasAssignmentRow: View {
     let assignment: CanvasAssignment
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(assignment.title)
-                .font(.body)
-                .strikethrough(assignment.isCompleted)
-                .foregroundColor(assignment.isCompleted ? .secondary : .primary)
 
-            Text(assignment.dueDate, style: .time)
+            HStack(spacing: 6) {
+                Text(assignment.title)
+                    .font(.body)
+                    .strikethrough(assignment.isCompleted)
+                    .foregroundColor(assignment.isCompleted ? .secondary : .primary)
+            }
+
+            HStack {
+                Text(assignment.dueDate, style: .date)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text(assignment.dueDate, style: .time)
+            }
+            .font(.caption)
+            .foregroundColor(.gray)
+
+            Text("Assignment")
                 .font(.caption)
-                .foregroundColor(assignment.isCompleted ? .secondary : Color.channelClay)
+                .foregroundColor(Color.channelClay)
         }
         .padding(.vertical, 4)
     }

--- a/PodConnect/Screens/CalendarView.swift
+++ b/PodConnect/Screens/CalendarView.swift
@@ -7,12 +7,14 @@ import SwiftUI
 
 struct CalendarView: View {
     @EnvironmentObject var assignmentsViewModel: AssignmentsViewModel
+    @ObservedObject private var authService: AuthService
     @StateObject private var viewModel: CalendarViewModel
     @State private var selectedTab = 0
     @State private var showAddEvent = false
     @State private var selectedDate = Date()
 
-    init(eventRepository: EventRepository) {
+    init(eventRepository: EventRepository, authService: AuthService) {
+        self.authService = authService
         _viewModel = StateObject(wrappedValue: CalendarViewModel(eventRepository: eventRepository))
     }
 
@@ -39,12 +41,29 @@ struct CalendarView: View {
                             assignments: assignmentsViewModel.assignments,
                             selectedDate: $selectedDate,
                             selectedTab: $selectedTab,
-                            onDeleteEvent: { event in Task { await viewModel.deleteEvent(event: event) } },
-                            onDeleteSeries: { groupId in Task { await viewModel.deleteEventSeries(groupId: groupId) } },
-                            onEditEvent: { event in Task { await viewModel.updateEvent(event: event) } },
-                            onEditSeries: { event in
-                                guard let groupId = event.recurrenceGroupId else { return }
-                                Task { await viewModel.updateEventSeries(groupId: groupId, template: event) }
+                            onDeleteEvent: { event in
+                                Task {
+                                    await removeClassFromProfileIfNeeded(event)
+                                    await viewModel.deleteEvent(event: event)
+                                }
+                            },
+                            onDeleteSeries: { groupId in
+                                Task {
+                                    await removeClassSeriesFromProfileIfNeeded(groupId)
+                                    await viewModel.deleteEventSeries(groupId: groupId)
+                                }
+                            },
+                            onEditEvent: { updatedEvent in
+                                Task {
+                                    await viewModel.updateEvent(event: updatedEvent)
+                                }
+                            },
+                            onEditSeries: { updatedEvent in
+                                guard let groupId = updatedEvent.recurrenceGroupId else { return }
+                                Task {
+                                    await syncProfileClassNameIfNeeded(updatedEvent)
+                                    await viewModel.updateEventSeries(groupId: groupId, template: updatedEvent)
+                                }
                             }
                         )
                     } else {
@@ -52,12 +71,29 @@ struct CalendarView: View {
                             userEvents: viewModel.userEvents,
                             selectedDate: $selectedDate,
                             selectedTab: $selectedTab,
-                            onDeleteEvent: { event in Task { await viewModel.deleteEvent(event: event) } },
-                            onDeleteSeries: { groupId in Task { await viewModel.deleteEventSeries(groupId: groupId) } },
-                            onEditEvent: { event in Task { await viewModel.updateEvent(event: event) } },
-                            onEditSeries: { event in
-                                guard let groupId = event.recurrenceGroupId else { return }
-                                Task { await viewModel.updateEventSeries(groupId: groupId, template: event) }
+                            onDeleteEvent: { event in
+                                Task {
+                                    await removeClassFromProfileIfNeeded(event)
+                                    await viewModel.deleteEvent(event: event)
+                                }
+                            },
+                            onDeleteSeries: { groupId in
+                                Task {
+                                    await removeClassSeriesFromProfileIfNeeded(groupId)
+                                    await viewModel.deleteEventSeries(groupId: groupId)
+                                }
+                            },
+                            onEditEvent: { updatedEvent in
+                                Task {
+                                    await viewModel.updateEvent(event: updatedEvent)
+                                }
+                            },
+                            onEditSeries: { updatedEvent in
+                                guard let groupId = updatedEvent.recurrenceGroupId else { return }
+                                Task {
+                                    await syncProfileClassNameIfNeeded(updatedEvent)
+                                    await viewModel.updateEventSeries(groupId: groupId, template: updatedEvent)
+                                }
                             }
                         )
                     }
@@ -65,12 +101,118 @@ struct CalendarView: View {
             }
         }
         .navigationBarHidden(true)
+        .onAppear {
+            Task {
+                await viewModel.fetchEvents()
+            }
+        }
         .sheet(isPresented: $showAddEvent) {
             AddEventSheet(initialDate: selectedDate) { events in
-                Task { await viewModel.saveEvents(events) }
+                Task {
+                    await viewModel.saveEvents(events)
+                    await viewModel.fetchEvents()
+
+                    if let firstEventDate = events.first?.startDate {
+                        selectedDate = firstEventDate
+                    }
+
+                    selectedTab = 0
+                }
             }
         }
     }
+    
+    private func classTitle(_ title: String) -> String {
+        title.components(separatedBy: "—").first?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? title
+    }
+
+    private func updateProfileClasses(_ classes: [String]) async {
+        guard let userInfo = authService.userInfo else { return }
+
+        let updatedProfile = UserInfo(
+            id: userInfo.id,
+            username: userInfo.username,
+            username_lowercase: userInfo.username_lowercase,
+            name: userInfo.name,
+            classes: classes,
+            clubs: userInfo.clubs,
+            friends: userInfo.friends,
+            email: userInfo.email,
+            uid: userInfo.uid,
+            bio: userInfo.bio,
+            profileImageURL: userInfo.profileImageURL,
+            classesVisibility: userInfo.classesVisibility,
+            clubsVisibility: userInfo.clubsVisibility
+        )
+
+        do {
+            try await authService.updateUserProfile(updatedProfile)
+        } catch {
+            print("Failed to sync profile classes: \(error)")
+        }
+    }
+
+    private func syncProfileClassNameIfNeeded(_ updatedEvent: UserEvent) async {
+        guard updatedEvent.category == .academic else { return }
+        guard let oldEvent = viewModel.userEvents.first(where: { $0.id == updatedEvent.id }) else { return }
+        guard oldEvent.category == .academic else { return }
+
+        let oldName = classTitle(oldEvent.title)
+        let newName = classTitle(updatedEvent.title)
+
+        guard oldName != newName else { return }
+        guard var classes = authService.userInfo?.classes else { return }
+
+        if let index = classes.firstIndex(of: oldName) {
+            classes[index] = newName
+        } else if !classes.contains(newName) {
+            classes.append(newName)
+        }
+
+        await updateProfileClasses(classes)
+    }
+
+    private func removeClassFromProfileIfNeeded(_ event: UserEvent) async {
+        guard event.category == .academic else { return }
+        let name = classTitle(event.title)
+
+        let remainingMatchingEvents = viewModel.userEvents.filter {
+            $0.id != event.id &&
+            $0.category == .academic &&
+            classTitle($0.title) == name
+        }
+
+        guard remainingMatchingEvents.isEmpty else { return }
+        guard var classes = authService.userInfo?.classes else { return }
+
+        classes.removeAll { $0 == name }
+        await updateProfileClasses(classes)
+    }
+
+    private func removeClassSeriesFromProfileIfNeeded(_ groupId: String) async {
+        let seriesEvents = viewModel.userEvents.filter {
+            $0.recurrenceGroupId == groupId &&
+            $0.category == .academic
+        }
+
+        guard let first = seriesEvents.first else { return }
+
+        let name = classTitle(first.title)
+
+        let remainingMatchingEvents = viewModel.userEvents.filter {
+            $0.recurrenceGroupId != groupId &&
+            $0.category == .academic &&
+            classTitle($0.title) == name
+        }
+
+        guard remainingMatchingEvents.isEmpty else { return }
+        guard var classes = authService.userInfo?.classes else { return }
+
+        classes.removeAll { $0 == name }
+        await updateProfileClasses(classes)
+    }
+    
 
     private var topHeader: some View {
         HStack {
@@ -118,8 +260,14 @@ struct CalendarTabView: View {
         schoolEvents.filter { Calendar.current.isDate($0.date, inSameDayAs: selectedDate) }
     }
 
-    private var userEventsOnDate: [UserEvent] {
+   /*private var userEventsOnDate: [UserEvent] {
         userEvents
+            .filter { Calendar.current.isDate($0.startDate, inSameDayAs: selectedDate) }
+            .sorted { $0.startDate < $1.startDate }
+    }*/
+    
+    private var userEventsOnDate: [UserEvent] {
+        return userEvents
             .filter { Calendar.current.isDate($0.startDate, inSameDayAs: selectedDate) }
             .sorted { $0.startDate < $1.startDate }
     }
@@ -341,7 +489,6 @@ struct EventsTabView: View {
     }
 
     private var filteredUserEvents: [UserEvent] {
-        let now = Date()
 
         let categoryFiltered: [UserEvent]
 
@@ -351,7 +498,8 @@ struct EventsTabView: View {
             categoryFiltered = userEvents.filter { activeCategories.contains($0.category.rawValue) }
         }
 
-        let futureFiltered = categoryFiltered.filter { $0.startDate >= now }
+        let today = Calendar.current.startOfDay(for: Date())
+        let futureFiltered = categoryFiltered.filter { $0.startDate >= today }
 
         let searchFiltered: [UserEvent]
 
@@ -838,12 +986,16 @@ struct EditEventSheet: View {
 }
 
 #Preview {
+    let firestoreService = FirestoreService()
+    let authService = AuthService(firestoreService: firestoreService)
+
     NavigationStack {
         CalendarView(
             eventRepository: EventRepository(
-                firestoreService: FirestoreService(),
-                authService: AuthService(firestoreService: FirestoreService())
-            )
+                firestoreService: firestoreService,
+                authService: authService
+            ),
+            authService: authService
         )
         .environmentObject(AssignmentsViewModel())
     }

--- a/PodConnect/Screens/CalendarView.swift
+++ b/PodConnect/Screens/CalendarView.swift
@@ -69,6 +69,7 @@ struct CalendarView: View {
                     } else {
                         EventsTabView(
                             userEvents: viewModel.userEvents,
+                            assignments: assignmentsViewModel.assignments,
                             selectedDate: $selectedDate,
                             selectedTab: $selectedTab,
                             onDeleteEvent: { event in
@@ -260,11 +261,6 @@ struct CalendarTabView: View {
         schoolEvents.filter { Calendar.current.isDate($0.date, inSameDayAs: selectedDate) }
     }
 
-   /*private var userEventsOnDate: [UserEvent] {
-        userEvents
-            .filter { Calendar.current.isDate($0.startDate, inSameDayAs: selectedDate) }
-            .sorted { $0.startDate < $1.startDate }
-    }*/
     
     private var userEventsOnDate: [UserEvent] {
         return userEvents
@@ -453,6 +449,7 @@ struct CalendarTabView: View {
 // MARK: - Events Tab
 struct EventsTabView: View {
     var userEvents: [UserEvent]
+    var assignments: [CanvasAssignment]
     @Binding var selectedDate: Date
     @Binding var selectedTab: Int
     var onDeleteEvent: (UserEvent) -> Void
@@ -470,6 +467,27 @@ struct EventsTabView: View {
 
     private let allCategories = ["Academic", "Arts", "Campus Life", "Wellness", "Personal", "Work", "Other"]
 
+    
+    private var filteredAssignments: [CanvasAssignment] {
+        let today = Calendar.current.startOfDay(for: Date())
+
+        let futureAssignments = assignments.filter {
+            $0.dueDate >= today
+        }
+
+        if searchText.isEmpty {
+            return futureAssignments.sorted { $0.dueDate < $1.dueDate }
+        }
+
+        return futureAssignments
+            .filter {
+                $0.title.localizedCaseInsensitiveContains(searchText)
+            }
+            .sorted { $0.dueDate < $1.dueDate }
+    }
+    
+    
+    
     private var filteredSchoolEvents: [SchoolEvent] {
         let categoryFiltered: [SchoolEvent]
 
@@ -573,6 +591,21 @@ struct EventsTabView: View {
             Divider()
 
             List {
+                
+                if !filteredAssignments.isEmpty {
+                    Section("Assignments") {
+                        ForEach(filteredAssignments) { assignment in
+                            Button {
+                                selectedDate = assignment.dueDate
+                                selectedTab = 0
+                            } label: {
+                                CanvasAssignmentRow(assignment: assignment)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                
                 if !filteredUserEvents.isEmpty {
                     Section("My Events") {
                         ForEach(filteredUserEvents) { event in
@@ -629,7 +662,7 @@ struct EventsTabView: View {
                     }
                 }
 
-                if filteredUserEvents.isEmpty && groupedSchoolEvents.isEmpty {
+                if filteredAssignments.isEmpty && filteredUserEvents.isEmpty && groupedSchoolEvents.isEmpty {
                     Text("No matching events")
                         .foregroundColor(.secondary)
                 }

--- a/PodConnect/Screens/ContentView.swift
+++ b/PodConnect/Screens/ContentView.swift
@@ -48,7 +48,8 @@ struct ContentView: View {
                             eventRepository: EventRepository(
                                 firestoreService: firestoreService,
                                 authService: authService
-                            )
+                            ),
+                            authService: authService
                         )
                     }
                     .tabItem {

--- a/PodConnect/Screens/HomeView.swift
+++ b/PodConnect/Screens/HomeView.swift
@@ -123,8 +123,12 @@ struct HomeView: View {
                 await calendarViewModel.fetchEvents()
             }
             .sheet(isPresented: $showAddClass) {
-                AddClassView { events in
-                    Task { await calendarViewModel.saveEvents(events) }
+                AddClassView { events, className in
+                    Task {
+                        await calendarViewModel.saveEvents(events)
+                        await calendarViewModel.fetchEvents()
+                        await addClassToProfile(className)
+                    }
                 }
             }
             .sheet(isPresented: $showNotifications) {
@@ -135,6 +139,40 @@ struct HomeView: View {
                     isPresented: $showNotifications
                 )
             }
+        }
+    }
+    
+    private func addClassToProfile(_ className: String) async {
+        let trimmed = className.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard let userInfo = authService.userInfo else { return }
+
+        var updatedClasses = userInfo.classes
+
+        if !updatedClasses.contains(trimmed) {
+            updatedClasses.append(trimmed)
+        }
+
+        let updatedProfile = UserInfo(
+            id: userInfo.id,
+            username: userInfo.username,
+            username_lowercase: userInfo.username_lowercase,
+            name: userInfo.name,
+            classes: updatedClasses,
+            clubs: userInfo.clubs,
+            friends: userInfo.friends,
+            email: userInfo.email,
+            uid: userInfo.uid,
+            bio: userInfo.bio,
+            profileImageURL: userInfo.profileImageURL,
+            classesVisibility: userInfo.classesVisibility,
+            clubsVisibility: userInfo.clubsVisibility
+        )
+
+        do {
+            try await authService.updateUserProfile(updatedProfile)
+        } catch {
+            print("Failed to update profile classes: \(error)")
         }
     }
 

--- a/PodConnect/Screens/ProfileView.swift
+++ b/PodConnect/Screens/ProfileView.swift
@@ -24,7 +24,6 @@ struct ProfileView: View {
     @State private var profileImageData: Data?
     @State private var profileImageURL: String?
     @State private var isUploadingProfileImage = false
-    @State private var newClassName = ""
 
     @State private var email = ""
     @State private var username = ""
@@ -288,20 +287,6 @@ struct ProfileView: View {
                                 }
                             }
                         }
-                        
-                        HStack {
-                            TextField("Add class", text: $newClassName)
-                                .textFieldStyle(.roundedBorder)
-
-                            Button {
-                                addTypedClass()
-                            } label: {
-                                Image(systemName: "plus.circle.fill")
-                                    .foregroundColor(Color.islandsBlue)
-                                    .font(.title3)
-                            }
-                            .buttonStyle(.plain)
-                        }
 
                     }
 
@@ -488,16 +473,7 @@ struct ProfileView: View {
         }
     }
     
-    func addTypedClass() {
-        let trimmed = newClassName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
 
-        if !selectedClasses.contains(trimmed) {
-            selectedClasses.append(trimmed)
-        }
-
-        newClassName = ""
-    }
     
     func classTitle(_ title: String) -> String {
         title.components(separatedBy: "—").first?

--- a/PodConnect/Screens/ProfileView.swift
+++ b/PodConnect/Screens/ProfileView.swift
@@ -24,6 +24,7 @@ struct ProfileView: View {
     @State private var profileImageData: Data?
     @State private var profileImageURL: String?
     @State private var isUploadingProfileImage = false
+    @State private var newClassName = ""
 
     @State private var email = ""
     @State private var username = ""
@@ -47,11 +48,6 @@ struct ProfileView: View {
     @State private var clubsVisibility: VisibilityLevel = .public
 
     
-
-    let classes = [
-        "COMP 150", "COMP 162", "COMP 232", "COMP 262", "COMP 350",
-        "COMP 362", "COMP 354", "COMP 429", "MATH 240", "MATH 300", "ENGL 101"
-    ]
 
     init(authService: AuthService, friendRepository: FriendRepository) {
         _authService = ObservedObject(wrappedValue: authService)
@@ -269,33 +265,43 @@ struct ProfileView: View {
                     Text("Classes")
                         .font(.headline)
 
-                    Menu {
-                        ForEach(classes, id: \.self) { course in
-                            Button {
-                                toggleSelection(course, in: &selectedClasses)
-                            } label: {
+                    VStack(spacing: 10) {
+                        
+                        if selectedClasses.isEmpty {
+                            Text("No classes added")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(selectedClasses.indices, id: \.self) { index in
                                 HStack {
-                                    Text(course)
-                                    if selectedClasses.contains(course) {
-                                        Image(systemName: "checkmark")
+                                    TextField("Class", text: $selectedClasses[index])
+                                        .textFieldStyle(.roundedBorder)
+
+                                    Button {
+                                        selectedClasses.remove(at: index)
+                                    } label: {
+                                        Image(systemName: "trash")
+                                            .foregroundColor(.red)
                                     }
+                                    .buttonStyle(.plain)
                                 }
                             }
                         }
-                    } label: {
+                        
                         HStack {
-                            Text(selectedClasses.isEmpty ? "Select classes" : selectedClasses.joined(separator: ", "))
-                                .foregroundColor(selectedClasses.isEmpty ? .gray : .primary)
-                                .lineLimit(2)
+                            TextField("Add class", text: $newClassName)
+                                .textFieldStyle(.roundedBorder)
 
-                            Spacer()
-
-                            Image(systemName: "chevron.down")
-                                .foregroundColor(.gray)
+                            Button {
+                                addTypedClass()
+                            } label: {
+                                Image(systemName: "plus.circle.fill")
+                                    .foregroundColor(Color.islandsBlue)
+                                    .font(.title3)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .padding()
-                        .background(Color(.systemBackground))
-                        .cornerRadius(10)
+
                     }
 
                     Picker("Classes Visibility", selection: $classesVisibility) {
@@ -480,6 +486,17 @@ struct ProfileView: View {
             }
         }
     }
+    
+    func addTypedClass() {
+        let trimmed = newClassName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        if !selectedClasses.contains(trimmed) {
+            selectedClasses.append(trimmed)
+        }
+
+        newClassName = ""
+    }
 
     func handleSelectedPhoto() async {
         guard let item = selectedPhotoItem else { return }
@@ -559,7 +576,7 @@ struct ProfileView: View {
             name: name,
             classes: selectedClasses,
             clubs: selectedClubs,
-            friends: [],
+            friends: authService.userInfo?.friends ?? [],
             email: email,
             uid: uid,
             bio: bio,

--- a/PodConnect/Screens/ProfileView.swift
+++ b/PodConnect/Screens/ProfileView.swift
@@ -33,6 +33,7 @@ struct ProfileView: View {
 
     @State private var selectedClubs: [String] = []
     @State private var selectedClasses: [String] = []
+    @State private var originalClasses: [String] = []
     @State private var clubOptions: [String] = []
 
     @State private var isEditing = false
@@ -497,6 +498,66 @@ struct ProfileView: View {
 
         newClassName = ""
     }
+    
+    func classTitle(_ title: String) -> String {
+        title.components(separatedBy: "—").first?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? title
+    }
+
+    func renamedEventTitle(oldTitle: String, newClassName: String) -> String {
+        let parts = oldTitle.components(separatedBy: "—")
+
+        if parts.count > 1 {
+            let location = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            return "\(newClassName) — \(location)"
+        }
+
+        return newClassName
+    }
+
+    func syncProfileClassChangesToCalendar() async {
+        let eventRepository = EventRepository(
+            firestoreService: FirestoreService(),
+            authService: authService
+        )
+
+        do {
+            let events = try await eventRepository.fetchEvents()
+            let academicEvents = events.filter { $0.category == .academic }
+
+            let trimmedOriginal = originalClasses.map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }.filter { !$0.isEmpty }
+
+            let trimmedSelected = selectedClasses.map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            }.filter { !$0.isEmpty }
+
+            let deletedClasses = trimmedOriginal.filter { !trimmedSelected.contains($0) }
+            let addedClasses = trimmedSelected.filter { !trimmedOriginal.contains($0) }
+
+            if deletedClasses.count == 1 && addedClasses.count == 1 {
+                let oldName = deletedClasses[0]
+                let newName = addedClasses[0]
+
+                for event in academicEvents where classTitle(event.title) == oldName {
+                    var updatedEvent = event
+                    updatedEvent.title = renamedEventTitle(oldTitle: event.title, newClassName: newName)
+                    try await eventRepository.updateEvent(event: updatedEvent)
+                }
+            } else {
+                for deletedClass in deletedClasses {
+                    for event in academicEvents where classTitle(event.title) == deletedClass {
+                        try await eventRepository.deleteEvent(event: event)
+                    }
+                }
+            }
+
+            originalClasses = selectedClasses
+        } catch {
+            print("Failed to sync profile classes to calendar: \(error)")
+        }
+    }
 
     func handleSelectedPhoto() async {
         guard let item = selectedPhotoItem else { return }
@@ -558,6 +619,7 @@ struct ProfileView: View {
         currentUID = userInfo.uid
         selectedClubs = userInfo.clubs
         selectedClasses = userInfo.classes
+        originalClasses = userInfo.classes
         profileImageURL = userInfo.profileImageURL
         classesVisibility = userInfo.classesVisibility
         clubsVisibility = userInfo.clubsVisibility
@@ -569,6 +631,8 @@ struct ProfileView: View {
         guard !currentUID.isEmpty else { return }
         let uid = currentUID
 
+        await syncProfileClassChangesToCalendar()
+        
         let profile = UserInfo(
             id: uid,
             username: username,

--- a/PodConnect/ViewModels/AssignmentsViewModel.swift
+++ b/PodConnect/ViewModels/AssignmentsViewModel.swift
@@ -33,7 +33,8 @@ final class AssignmentsViewModel: ObservableObject {
 
     var todaysAssignments: [CanvasAssignment] {
         assignments.filter {
-            Calendar.current.isDateInToday($0.dueDate)
+            Calendar.current.isDateInToday($0.dueDate) &&
+            $0.dueDate >= Date()
         }
     }
 


### PR DESCRIPTION
Implemented unified class management across Home, Calendar, Events, and Profile.

Changes:
- Added editable typed class entries in ProfileView
- Removed hardcoded class dropdown menu
- Added ability to add, remove, and edit classes directly from profile
- Linked Home AddClass flow to UserInfo.classes
- Classes added from Home now:
  - create recurring academic calendar events
  - appear in Home Classes card
  - appear in Calendar + Events tab
  - sync to Profile + Public Profile
- Updated ClassesCardView to show all classes for the current day
- Improved live UI refresh after adding classes/events
- Preserved existing visibility controls and profile-sharing behavior
- Added Canvas help popup to Assignments screen
- Added quick navigation guidance for Canvas calendar import via Account Settings

Synchronization updates:
- Synced Profile class renaming with full recurring calendar series updates
- Synced Profile class deletion with recurring calendar event deletion
- Synced Calendar series edits with Profile + Home updates
- Preserved isolated single-event editing behavior in Calendar
- Single-event edits now only affect the edited occurrence
- Home Classes card now reflects only today’s edited instance when applicable
- Fixed Calendar event visibility and same-day filtering behavior
- Added consistent cross-screen syncing between:
  - Home
  - Calendar
  - Events tab
  - Profile
  - Public Profile

Architecture:
- Academic UserEvents remain the schedule source of truth
- UserInfo.classes remains the lightweight shareable profile representation